### PR TITLE
Fix typo

### DIFF
--- a/source/rvi.rst
+++ b/source/rvi.rst
@@ -1028,7 +1028,7 @@ lhu
 
 
 :Format:
-  | lhu        rs2,offset(rs1)
+  | lhu        rd,offset(rs1)
 
 :Description:
   | Loads a 16-bit value from memory and zero-extends this to XLEN bits before storing it in register rd.


### PR DESCRIPTION
lhu takes the same syntax as the other loads, with rd as the first argument. I suspect this was a typo and used the syntax of the store instructions instead