### PR TITLE
Fix typo in btlu implementation note

### DIFF
--- a/source/rvi.rst
+++ b/source/rvi.rst
@@ -1281,7 +1281,7 @@ bltu
 :Description:
   | Take the branch if registers rs1 is less than rs2, using unsigned comparison.
 :Implementation:
-  | if (x[rs1] >u x[rs2]) pc += sext(offset)
+  | if (x[rs1] <u x[rs2]) pc += sext(offset)
 
 
 bgeu


### PR DESCRIPTION
The implementation note for `bltu` listed `>` (greater than). It was updated to `<` (less than).