### PR TITLE
Fix rvfd instruction descriptions.

### DIFF
--- a/source/rvfd.adoc
+++ b/source/rvfd.adoc
@@ -70,7 +70,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision fused multiply addition.
+  Perform negated single-precision fused multiply subtraction.
   --
 Implementation::
   [verse]
@@ -96,7 +96,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision fused multiply addition.
+  Perform negated single-precision fused multiply addition.
   --
 Implementation::
   [verse]
@@ -463,7 +463,7 @@ Format::
 Description::
   [verse]
   --
-  Performs a quiet equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+  Performs a quiet equal comparison between single-precision floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
   Only signaling NaN inputs cause an Invalid Operation exception.
   The result is 0 if either operand is NaN.
   --
@@ -491,7 +491,7 @@ Format::
 Description::
   [verse]
   --
-  Performs a quiet less comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+  Performs a quiet less comparison between single-precision floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
   Only signaling NaN inputs cause an Invalid Operation exception.
   The result is 0 if either operand is NaN.
   --
@@ -519,7 +519,7 @@ Format::
 Description::
   [verse]
   --
-  Performs a quiet less or equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+  Performs a quiet less or equal comparison between single-precision floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
   Only signaling NaN inputs cause an Invalid Operation exception.
   The result is 0 if either operand is NaN.
   --
@@ -547,7 +547,7 @@ Format::
 Description::
   [verse]
   --
-  Examines the value in floating-point register rs1 and writes to integer register rd a 10-bit mask that indicates the class of the floating-point number.
+  Examines the value in single-precision floating-point register rs1 and writes to integer register rd a 10-bit mask that indicates the class of the floating-point number.
   The format of the mask is described in [classify table]_.
   The corresponding bit in rd will be set if the property is true and clear otherwise.
   All other bits in rd are cleared. Note that exactly one bit in rd will be set.
@@ -654,7 +654,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision fused multiply addition.
+  Perform double-precision fused multiply addition.
   --
 Implementation::
   [verse]
@@ -680,7 +680,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision fused multiply addition.
+  Perform double-precision fused multiply subtraction.
   --
 Implementation::
   [verse]
@@ -706,7 +706,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision fused multiply addition.
+  Perform negated double-precision fused multiply subtraction.
   --
 Implementation::
   [verse]
@@ -732,7 +732,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision fused multiply addition.
+  Perform negated double-precision fused multiply addition.
   --
 Implementation::
   [verse]
@@ -758,7 +758,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision floating-point addition.
+  Perform double-precision floating-point addition.
   --
 Implementation::
   [verse]
@@ -784,7 +784,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision floating-point addition.
+  Perform double-precision floating-point addition.
   --
 Implementation::
   [verse]
@@ -810,7 +810,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision floating-point addition.
+  Perform double-precision floating-point addition.
   --
 Implementation::
   [verse]
@@ -836,7 +836,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision floating-point addition.
+  Perform double-precision floating-point addition.
   --
 Implementation::
   [verse]
@@ -862,7 +862,7 @@ Format::
 Description::
   [verse]
   --
-  Perform single-precision square root.
+  Perform double-precision square root.
   --
 Implementation::
   [verse]
@@ -969,7 +969,7 @@ Format::
 Description::
   [verse]
   --
-  Write the smaller of single precision data in rs1 and rs2 to rd.
+  Write the smaller of double precision data in rs1 and rs2 to rd.
   --
 Implementation::
   [verse]
@@ -995,7 +995,7 @@ Format::
 Description::
   [verse]
   --
-  Write the larger of single precision data in rs1 and rs2 to rd.
+  Write the larger of double precision data in rs1 and rs2 to rd.
   --
 Implementation::
   [verse]
@@ -1073,7 +1073,7 @@ Format::
 Description::
   [verse]
   --
-  Performs a quiet equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+  Performs a quiet equal comparison between double-precision floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
   Only signaling NaN inputs cause an Invalid Operation exception.
   The result is 0 if either operand is NaN.
   --
@@ -1101,7 +1101,7 @@ Format::
 Description::
   [verse]
   --
-  Performs a quiet less comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+  Performs a quiet less comparison between double-precision floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
   Only signaling NaN inputs cause an Invalid Operation exception.
   The result is 0 if either operand is NaN.
   --
@@ -1129,7 +1129,7 @@ Format::
 Description::
   [verse]
   --
-  Performs a quiet less or equal comparison between floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
+  Performs a quiet less or equal comparison between double-precision floating-point registers rs1 and rs2 and record the Boolean result in integer register rd.
   Only signaling NaN inputs cause an Invalid Operation exception.
   The result is 0 if either operand is NaN.
   --
@@ -1157,7 +1157,7 @@ Format::
 Description::
   [verse]
   --
-  Examines the value in floating-point register rs1 and writes to integer register rd a 10-bit mask that indicates the class of the floating-point number.
+  Examines the value in double-precision floating-point register rs1 and writes to integer register rd a 10-bit mask that indicates the class of the floating-point number.
   The format of the mask is described in table [classify table]_.
   The corresponding bit in rd will be set if the property is true and clear otherwise.
   All other bits in rd are cleared. Note that exactly one bit in rd will be set.


### PR DESCRIPTION
- In some cases the description didn't specify if it was single or double precision
- In others it specified single when it was double
- `fmsub.s`, `fnmsub.s`, `fmsub.d` and `fnmsub.d` incorrectly stated that they used addition (Fixes #17)
- `fn***.*` didn't specify it was negated