### PR TITLE
Fix typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2678,7 +2678,7 @@
 <div class="content">
 <div class="literalblock">
 <div class="content">
-<pre>if (rs1 &gt;u rs2) pc += sext(offset)</pre>
+<pre>if (rs1 &lt;u rs2) pc += sext(offset)</pre>
 </div>
 </div>
 </div>


### PR DESCRIPTION
Fix typo in documentation where `>` is used instead of `<`in `bltu` instruction